### PR TITLE
Implemented `catch`.

### DIFF
--- a/tests/integration/arg_test.py
+++ b/tests/integration/arg_test.py
@@ -1,7 +1,5 @@
 """Various tests for `candies.cli.args.arg.Arg`."""
 
-from typing import Any
-
 import pytest
 
 from mints.cli import cli, CLI

--- a/tests/integration/flag_test.py
+++ b/tests/integration/flag_test.py
@@ -1,6 +1,5 @@
 """Various tests for `candies.cli.args.flag.Flag`."""
 
-from typing import Any
 from argparse import ArgumentError
 
 import pytest


### PR DESCRIPTION
## Purpose
Added an ability to specify handlers for errors raised during execution of a command (#38).

## Approach
Extended the `Command` class with a decorator method `@catch` that allows defining error handlers for different exception types.

### Open Questions
- [ ] How should we specify a handler for multiple exception types?

  For now, an ability to specify a single function for handling multiple exception types is implemented via `Union`.
  For example,

  ```py
  @whatever.catch
  def _(error: Union[ValueError, TypeError]):
      pass
  ```
- [ ] Do we need to provide an ability to define error handler functions without parameters?
  For example,
  
  ```py
  @whatever.catch(ValueError)
  def _():
      pass
  ```

### Pre-Merge Checklist
- [x] Docstrings for new classes and functions are added.
- [ ] Documentation is added to the README file.
- [x] Tests are included.